### PR TITLE
remove @JoinColumn , generics from base model

### DIFF
--- a/src/main/java/ir/quiz/quiz/model/BaseModel.java
+++ b/src/main/java/ir/quiz/quiz/model/BaseModel.java
@@ -16,8 +16,8 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 @MappedSuperclass
-public abstract class BaseModel<ID extends Number> implements Serializable {
+public abstract class BaseModel implements Serializable {
     @Id
     @GeneratedValue
-    private ID id;
+    private Long id;
 }

--- a/src/main/java/ir/quiz/quiz/model/Course.java
+++ b/src/main/java/ir/quiz/quiz/model/Course.java
@@ -20,7 +20,7 @@ import static ir.quiz.quiz.model.Course.TABLE_NAME;
 @AllArgsConstructor
 @Entity
 @Table(name = TABLE_NAME)
-public class Course extends BaseModel<Long> {
+public class Course extends BaseModel {
     public static final String TABLE_NAME = "courses";
 
     @Column(length = 50)
@@ -36,7 +36,6 @@ public class Course extends BaseModel<Long> {
     private List<Student> students;
 
     @ManyToOne(cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "teacher_id")
     private Teacher teacher;
 
     @ManyToOne(cascade = CascadeType.REMOVE)

--- a/src/main/java/ir/quiz/quiz/model/Person.java
+++ b/src/main/java/ir/quiz/quiz/model/Person.java
@@ -2,6 +2,7 @@ package ir.quiz.quiz.model;
 
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -17,8 +18,9 @@ import static jakarta.persistence.InheritanceType.TABLE_PER_CLASS;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Entity
 @Inheritance(strategy = TABLE_PER_CLASS)
-public class Person<ID extends Number> extends BaseModel<ID> {
+public abstract class Person extends BaseModel {
 
     @Column(name = "first_name", length = 50)
     private String firstName;

--- a/src/main/java/ir/quiz/quiz/model/Principal.java
+++ b/src/main/java/ir/quiz/quiz/model/Principal.java
@@ -1,9 +1,6 @@
 package ir.quiz.quiz.model;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,15 +9,18 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+import static ir.quiz.quiz.model.Principal.TABLE_NAME;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Principal extends Person<Long> {
+@Table(name = TABLE_NAME)
+public class Principal extends Person {
+    public static final String TABLE_NAME = "principals";
 
     @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "principal")
-    @JoinColumn(name = "course_id")
     private List<Course> courses;
 }

--- a/src/main/java/ir/quiz/quiz/model/Student.java
+++ b/src/main/java/ir/quiz/quiz/model/Student.java
@@ -19,7 +19,7 @@ import static ir.quiz.quiz.model.Student.TABLE_NAME;
 @AllArgsConstructor
 @Entity
 @Table(name = TABLE_NAME)
-public class Student extends Person<Long> {
+public class Student extends Person {
     public static final String TABLE_NAME = "students";
 
     @ManyToMany(cascade = CascadeType.REMOVE)

--- a/src/main/java/ir/quiz/quiz/model/Teacher.java
+++ b/src/main/java/ir/quiz/quiz/model/Teacher.java
@@ -19,10 +19,9 @@ import static ir.quiz.quiz.model.Teacher.TABLE_NAME;
 @AllArgsConstructor
 @Entity
 @Table(name = TABLE_NAME)
-public class Teacher extends Person<Long> {
+public class Teacher extends Person {
     public static final String TABLE_NAME = "teachers";
 
     @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "teacher")
-    @JoinColumn(name = "course_id")
     private List<Course> courses;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,4 +2,7 @@ spring.application.name=quiz
 spring.datasource.url=jdbc:postgresql://localhost:5432/quiz
 spring.datasource.username=postgres
 spring.datasource.password=ernoxin
+spring.jpa.hibernate.ddl-auto=update
+spring.data.jdbc.dialect=postgresql
+spring.jpa.show-sql=true
 server.port=80


### PR DESCRIPTION
cause 1: when we use mappedby we shouldn't use this annotation
cause 2: Association 'ir.quiz.quiz.model.Principal.courses' is 'mappedBy' another entity and may not specify the '@JoinColumn'